### PR TITLE
Mark some strings as "raw"

### DIFF
--- a/epi_forecast_stat_mech/soft_laplace.py
+++ b/epi_forecast_stat_mech/soft_laplace.py
@@ -1,4 +1,4 @@
-"""### SoftLaplace Model
+r"""### SoftLaplace Model
 
 $$\varphi(x) = \exp\left(-\left(\sqrt{x^2 + 1} - 1\right) - d\right)$$
 $$d \approx 1.185495232349193$$

--- a/epi_forecast_stat_mech/viboud_chowell.py
+++ b/epi_forecast_stat_mech/viboud_chowell.py
@@ -1,4 +1,4 @@
-"""### Viboud Chowell Model
+r"""### Viboud Chowell Model
 
 
 This model states that if the infected number of infections at time $t$ is given by $$E(I_t) = r Y_t^p (1-Y_t/Y_\infty)^a, $$


### PR DESCRIPTION
It doesn't really matter, but otherwise Python mangles backslashes.