### PR TITLE
Modify stat_mech to have an observable_choice.

### DIFF
--- a/epi_forecast_stat_mech/mechanistic_models/mechanistic_models.py
+++ b/epi_forecast_stat_mech/mechanistic_models/mechanistic_models.py
@@ -156,25 +156,6 @@ class MechanisticModel:
     ...
 
   @abc.abstractmethod
-  def epidemic_observables(self, parameters, epidemics):
-    """Computes statistical observables of the epidemics.
-
-    Could be any set of values that represent global properties of the epidemics
-    e.g. total size of the epidemics or peak location.
-
-    Args:
-      parameters: parameters of the mechanistic model.
-      epidemics: observed epidemic trajectory.
-
-    Returns:
-      Pytree holding the estimates of statistical properties of
-      the epidemic based on the mechanistic model. This can vary between all
-      model parameters to a subset or other statistical predictions by the
-      model.
-    """
-    ...
-
-  @abc.abstractmethod
   def init_parameters(self):
     """Returns reasonable `parameters` for an initial guess."""
     ...
@@ -364,10 +345,6 @@ class StepBasedViboudChowellModel(IntensityModel):
     """Returns reasonable `parameters` for an initial guess."""
     return self.encode_params(jnp.asarray([2., .9, .9, 200000.]))
 
-  def epidemic_observables(self, parameters, epidemics):
-    """See base class."""
-    return {"epidemic_size": parameters[..., -1:]}
-
   def _split_and_scale_parameters(self, parameters):
     """Splits parameters and scales them appropriately.
 
@@ -507,10 +484,6 @@ class StepBasedMultiplicativeGrowthModel(IntensityModel):
     overdispersion = 2.
     return (jnp.maximum(o_hat, 0.1), overdispersion,)
 
-  def epidemic_observables(self, parameters, epidemics):
-    """See base class."""
-    return {"epidemic_size": parameters[..., -1:]}
-
   # These are kind of a compatibility layer thing.
   @property
   def param_names(self):
@@ -632,10 +605,6 @@ class ViboudChowellModel(MechanisticModel):
       return jnp.concatenate([observed_epidemics.infections_over_time, unroll])
     return unroll
 
-  def epidemic_observables(self, parameters, epidemics):
-    """See base class."""
-    return {"epidemic_size": parameters[..., -1:]}
-
 
 @dataclasses.dataclass
 class GaussianModel(MechanisticModel):
@@ -734,11 +703,6 @@ class GaussianModel(MechanisticModel):
     if include_observed:
       return jnp.concatenate([observed_epidemics.infections_over_time, unroll])
     return unroll
-
-  def epidemic_observables(self, parameters, epidemics):
-    """See base class."""
-    # Consider using the location of the peak as well.
-    return {"epidemic_size": parameters[..., -1:]}
 
 
 @dataclasses.dataclass
@@ -1007,10 +971,6 @@ class StepBasedBaselineSEIRModel(IntensityModel):
     # Observe that K folds together population and observation_rate.
     # Return a singleton tuple holding a float for the Poisson parameter.
     return (jnp.maximum(K * symptom_rate * exposed, 0.1),)
-
-  def epidemic_observables(self, parameters, epidemics):
-    """See base class."""
-    return {"epidemic_size": parameters[..., -1:]}
 
   # These are kind of a compatibility layer thing.
   @property

--- a/epi_forecast_stat_mech/mechanistic_models/observables.py
+++ b/epi_forecast_stat_mech/mechanistic_models/observables.py
@@ -1,0 +1,45 @@
+"""Abstract class to represent predictable properties of a mech_model."""
+import abc
+from jax import numpy as jnp
+
+
+class Observables(object):
+  """Computes statistical observables of the epidemics."""
+
+  @abc.abstractmethod
+  def observables(self, mech_model, mech_params, epidemic):
+    """Computes statistical observables of the epidemic.
+
+    Could be any set of values that represent global properties of the epidemics
+    e.g. total size of the epidemics or peak location.
+
+    Args:
+      mech_model: A MechanisticModel instance.
+      mech_params: Parameters of the mechanistic model (one location's worth).
+      epidemic: Observed epidemic trajectory (one location's worth).
+
+    Returns:
+      Pytree holding the estimates of statistical properties of
+      the epidemic based on the mechanistic model. This can vary between all
+      model parameters to a subset or other statistical predictions by the
+      model.
+    """
+    ...
+
+
+class InternalParams(Observables):
+
+  def observables(self, mech_model, mech_params, epidemic):
+    return dict(zip(mech_model.encoded_param_names,
+                    jnp.split(mech_params, len(mech_params))))
+
+
+class ObserveSpecified(Observables):
+
+  def __init__(self, specified_internal_params):
+    self._specified_internal_params = specified_internal_params
+
+  def observables(self, mech_model, mech_params, epidemic):
+    encoded_dict = InternalParams().observables(mech_model, mech_params,
+                                                epidemic)
+    return {key: encoded_dict[key] for key in self._specified_internal_params}

--- a/epi_forecast_stat_mech/mechanistic_models/observables.py
+++ b/epi_forecast_stat_mech/mechanistic_models/observables.py
@@ -34,12 +34,23 @@ class InternalParams(Observables):
                     jnp.split(mech_params, len(mech_params))))
 
 
+class AllDefinedObservables(Observables):
+
+  def observables(self, mech_model, mech_params, epidemic):
+    d1 = dict(
+        zip(mech_model.encoded_param_names,
+            jnp.split(mech_params, len(mech_params))))
+    d2 = mech_model.epidemic_observables(mech_params, epidemic)
+    d1.update(d2)
+    return d1
+
+
 class ObserveSpecified(Observables):
 
   def __init__(self, specified_internal_params):
     self._specified_internal_params = specified_internal_params
 
   def observables(self, mech_model, mech_params, epidemic):
-    encoded_dict = InternalParams().observables(mech_model, mech_params,
-                                                epidemic)
+    encoded_dict = AllDefinedObservables().observables(mech_model, mech_params,
+                                                       epidemic)
     return {key: encoded_dict[key] for key in self._specified_internal_params}

--- a/epi_forecast_stat_mech/mechanistic_models/observables_test.py
+++ b/epi_forecast_stat_mech/mechanistic_models/observables_test.py
@@ -1,0 +1,47 @@
+"""Tests for epi_forecast_stat_mech.mechanistic_models.observables."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from epi_forecast_stat_mech.mechanistic_models import mechanistic_models
+from epi_forecast_stat_mech.mechanistic_models import observables
+import numpy as np
+from jax import numpy as jnp
+from jax.config import config
+
+
+config.parse_flags_with_absl()  # Necessary for running on TPU.
+
+
+class ObservablesTest(parameterized.TestCase):
+  # jnp's can't be in arguments, so we cast the expected result after the fact.
+  @parameterized.parameters(
+      dict(
+          observable=observables.ObserveSpecified(['log_K']),
+          mech_model=mechanistic_models.ViboudChowellModel(),
+          mech_params=np.asarray([1., 1., 1., 10.], dtype=np.float32),
+          epidemic=None,
+          expected_result={'log_K': np.float32([10.])}),
+      dict(
+          observable=observables.InternalParams(),
+          mech_model=mechanistic_models.ViboudChowellModel(),
+          mech_params=np.asarray([1., 1., 1., 10.], dtype=np.float32),
+          epidemic=None,
+          expected_result={'log_r': np.float32([1.]),
+                           'log_a': np.float32([1.]),
+                           'log_p': np.float32([1.]),
+                           'log_K': np.float32([10.])}),
+  )
+  def test_expected(self, observable, mech_model, mech_params, epidemic,
+                    expected_result):
+    jnp_expected_result = {
+        key: jnp.asarray(value) for key, value in expected_result.items()
+    }
+    result = observable.observables(mech_model, mech_params, epidemic)
+    self.assertSameStructure(result, jnp_expected_result)
+    for key, value in result.items():
+      expected_value = jnp_expected_result[key]
+      self.assertAlmostEqual(np.asarray(value), expected_value, places=3)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/epi_forecast_stat_mech/stat_mech_estimator.py
+++ b/epi_forecast_stat_mech/stat_mech_estimator.py
@@ -308,4 +308,17 @@ def get_estimator_dict(
         time_mask_fn=time_mask_fn,
         fit_seed=fit_seed,
         observable_choice=observable_choice)
+  estimator_dictionary["Laplace_VC_Linear_ObsChar1"] = StatMechEstimator(
+      train_steps=train_steps,
+      stat_model=network_models.NormalDistributionModel(
+          predict_module=network_models.LinearModule,
+          log_prior_fn=laplace_prior),
+      mech_model=mechanistic_models.ViboudChowellModel(),
+      fused_train_steps=fused_train_steps,
+      time_mask_fn=time_mask_fn,
+      fit_seed=fit_seed,
+      observable_choice=observables.ObserveSpecified([
+          "log_r", "log_a", "log_characteristic_time",
+          "log_characteristic_height"
+      ]))
   return estimator_dictionary

--- a/epi_forecast_stat_mech/statistical_models/network_models.py
+++ b/epi_forecast_stat_mech/statistical_models/network_models.py
@@ -117,3 +117,14 @@ class NormalDistributionModel(base.StatisticalModel):
     return jax.tree_multimap(
         lambda l, s: tfd.Normal(loc=l, scale=s),
         unpack_fn(loc), unpack_fn(scale))
+
+  def linear_coefficients(self, parameters):
+    dense_name = [x for x in parameters.keys() if "Dense" in x][0]
+    kernel = parameters[dense_name]["kernel"]
+    bias = parameters[dense_name]["bias"]
+    if self.fixed_scale is None:
+      kernel, _ = jnp.split(kernel, 2, -1)
+      bias, _ = jnp.split(bias, 2, -1)
+    return kernel, bias
+
+

--- a/epi_forecast_stat_mech/tests/test_high_level.py
+++ b/epi_forecast_stat_mech/tests/test_high_level.py
@@ -144,6 +144,7 @@ class TestEstimatorDictEstimator(parameterized.TestCase):
       dict(estimator_name='None_VC_Linear'),
       dict(estimator_name='Laplace_Gaussian_PL_Linear'),
       dict(estimator_name='None_VC_Linear_ObsEnc'),
+      dict(estimator_name='Laplace_VC_Linear_ObsChar1'),
   )
   def test_EstimatorDictEstimatorWithCoef(self, estimator_name):
     """Verify we can fit and predict from the named estimator.

--- a/epi_forecast_stat_mech/tests/test_high_level.py
+++ b/epi_forecast_stat_mech/tests/test_high_level.py
@@ -143,7 +143,7 @@ class TestEstimatorDictEstimator(parameterized.TestCase):
   @parameterized.parameters(
       dict(estimator_name='None_VC_Linear'),
       dict(estimator_name='Laplace_Gaussian_PL_Linear'),
-      dict(estimator_name='None_BaselineSEIR_Linear'),
+      dict(estimator_name='None_VC_Linear_ObsEnc'),
   )
   def test_EstimatorDictEstimatorWithCoef(self, estimator_name):
     """Verify we can fit and predict from the named estimator.
@@ -169,7 +169,6 @@ class TestEstimatorDictEstimator(parameterized.TestCase):
     self.assertLen(predictions.sample, num_samples)
 
   @parameterized.parameters(
-      dict(estimator_name='iterative_mean__DynamicMultiplicative'),
       dict(estimator_name='iterative_randomforest__DynamicMultiplicative'),
       dict(estimator_name='iterative_mean__DynamicBaselineSEIRModel'),
   )


### PR DESCRIPTION
Modify stat_mech to have an observable_choice.

observables.Observable is an abstract class representing choice of which "observables" to train the stat_model to predict, and in consequence, a choice of a way to regularize the stat_mech model.
